### PR TITLE
acidphantasm-progressivebotsystem log exclusion

### DIFF
--- a/ModSync.Server/src/config.ts
+++ b/ModSync.Server/src/config.ts
@@ -64,7 +64,9 @@ const DEFAULT_CONFIG = `{
 		"user/mods/**/node_modules",
 		"user/mods/**/*.js",
 		"user/mods/**/*.js.map",
-		"**/*:Zone.Identifier"
+		"**/*:Zone.Identifier",
+		// acidphantasm-progressivebotsystem logs
+		"user/mods/acidphantasm-progressivebotsystem/logs"
 	]
 }`;
 


### PR DESCRIPTION
Need to exclude this folder or you'll be downloading logs every server restart